### PR TITLE
Change squid_log to just match the access log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Log format description files for lnav
 
-[http://lnav.org](lnav) is a powerful log file reader, designed to take
+[lnav](https://lnav.org) is a powerful log file reader, designed to take
 multiple log files and order them by date.  It understands log file formats
 using regular expresions and can highlight sections of line, find errors
 and warnings, and more.

--- a/squid.json
+++ b/squid.json
@@ -4,23 +4,22 @@
 		"description"	: "Log format used by the Squid HTTP cache",
 		"url"			: "http://wiki.squid-cache.org/Features/LogFormat",
 		"regex" : {
-			"access_get_request"	: {
-				"pattern" : "^(?<timestamp>\\d+(?:\\.\\d{3})?)\\s+(?<duration>\\d+)\\s+(?<client>(?:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})) (?<req_type>\\w+)/(?<response_code>\\d+) (?<resp_size>\\d+) GET (?<body>https?://\\S+) (?<user>\\w+|-) (?<method>\\w+)(?:/(?<source>\\S+)) (?<mime_type>\\w+/\\w+|-)$"
-			},
 			"default"	: {
-				"pattern" : "^(?<timestamp>\\d{4}/\\d{2}/\\d{2} (?:\\d |\\d\\d):\\d{2}:\\d{2})\\|\\s+(?<body>.*)$"
+				"pattern" : "^(?<timestamp>\\d+(?:\\.\\d{3})?)\\s+(?<duration>\\d+)\\s+(?<client>(?:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})) (?<req_type>\\w+)/(?<response_code>\\d+) (?<resp_size>\\d+) (?<method>\\w+) (?<body>https?://\\S+) (?<user>\\S+) (?<hier>\\w+)(?:/(?<source>\\S+)) (?<mime_type>.*)$"
 			}
 		},
+		"multiline" : false,
 		"timestamp-format" : [ "%s.%i" ],
 		"value" : {
 			"duration"	: { "kind" : "integer" },
-			"client"	: { "kind" : "string", "identifier" : true },
+			"client"	: { "kind" : "string", "identifier" : true, "collate" : "ipaddress" },
 			"req_type"	: { "kind" : "string", "identifier" : true },
-			"response_code"	: { "kind" : "integer", "identifier" : true },
+			"response_code"	: { "kind" : "integer", "identifier" : true, "foreign-key" : true },
 			"resp_size"	: { "kind" : "integer" },
 			"body"		: { "kind" : "string" },
 			"method"	: { "kind" : "string", "identifier" : true },
-			"source"	: { "kind" : "string", "identifier" : true },
+			"hier"          : { "kind" : "string", "identifier" : true },
+			"source"	: { "kind" : "string", "identifier" : true, "collate" : "ipaddress" },
 			"mime_type"	: { "kind" : "string", "identifier" : true }
 		},
 		"sample" : [
@@ -32,9 +31,6 @@
 			},
 			{
 				"line" 	: "1436799758.045    955 127.0.0.1 TCP_MISS/200 70113 GET http://example.org/example.bin - DIRECT/10.20.130.12 application/octet-stream"
-			},
-			{
-				"line"	: "2015/06/19 16:44:04| Creating Swap Directories"
 			}
 		]
 	}


### PR DESCRIPTION
The other message pattern should be a separate format.  Other changes:
- Set multiline to false so config checking will complain about lines
  that do not match.
- Change the mime_type pattern to capture the rest of the line since it's
  the easiest way to get the whole type without missing anything.
- Accept more than just the GET method and change the existing 'method'
  capture to be 'hier'.
- Add 'ipaddress' collation for the client and source IP addresses.
- Set 'foreign-key' to true for the response_code so that it is not
  graphed in the SQL view.
