### PR TITLE
Update for Rocky 9.3 strace "resume" format.

### DIFF
--- a/strace.json
+++ b/strace.json
@@ -5,7 +5,7 @@
 		"url"			: "http://en.wikipedia.org/wiki/Strace",
 		"regex" : {
 			"new"	: {
-				"pattern" : "(?:(?<process_id>\\d+)\\s+)(?<timestamp>\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?) (?:(?<syscall>\\w+)\\((?<args>(?:[^)]*{[^}]+})*[^)]*)\\)?|(?<syscall_unfinished>\\w+)\\( <unfinished \\.\\.\\.>|<\\.\\.\\. (?<syscall_resumed>\\w+) resumed> (?<resume_args>.*)?|--- (?<signal>SIG\\w+) \\((?<signame>\\w+)\\) @ \\d+ \\(\\d+\\) ---$)(?:\\s+= (?<result>-?\\d+|0x[0-9a-f]+))?(?: (?<errname>\\w+))?(?: \\((?<errdesc>[^)]+)\\)?)?(?: <(?<duration>\\d+\\.\\d+)>)?$"
+				"pattern" : "(?:(?<process_id>\\d+)\\s+)(?<timestamp>\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?) (?:(?<syscall>\\w+)\\((?<args>(?:[^)]*{[^}]+})*[^)]*)\\)?|(?<syscall_unfinished>\\w+)\\( <unfinished \\.\\.\\.>|<\\.\\.\\. (?<syscall_resumed>\\w+) resumed> ?(?<resume_args>.*)?|--- (?<signal>SIG\\w+) \\((?<signame>\\w+)\\) @ \\d+ \\(\\d+\\) ---$)(?:\\s+= (?<result>-?\\d+|0x[0-9a-f]+))?(?: (?<errname>\\w+))?(?: \\((?<errdesc>[^)]+)\\)?)?(?: <(?<duration>\\d+\\.\\d+)>)?$"
 			}
 		},
 		"value" : {
@@ -23,6 +23,9 @@
 			"body"		: { "kind" : "string" }
 		},
 		"sample" : [
+		    {
+			"line":"45282 03:10:01 <... futex resumed>)     = 0"
+		    },
 			{
 				"line" 	: "12231 15:42:50 --- SIGINT (Interrupt) @ 0 (0) ---"
 			},


### PR DESCRIPTION
Rocky 9.3 has a slightly different format for the `resume` part of a system call, and this correctly matches it.